### PR TITLE
fix: Only deploy Sanity schema changes on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         run: pnpm test
 
   sanity:
-    name: Sanity Studio
+    name: Validate Sanity Schema
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,28 @@ jobs:
 
       - name: Run tests
         run: pnpm test
+
+  sanity:
+    name: Sanity Studio
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.x"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate Sanity schema
+        run: pnpm sanity schema extract --enforce-required-fields
+
+      - name: Build Sanity Studio
+        run: pnpm sanity build

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -3,16 +3,19 @@ name: Sanity
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sanity-deploy-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   deploy-sanity:
     name: Deploy Sanity Studio
     runs-on: ubuntu-latest
-    permissions: write-all
-    if: ${{ github.actor != 'dependabot[bot]' }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Sanity tests were running and [failing](https://github.com/namesakefyi/namesake/actions/runs/25052294299/job/73442470171?pr=501) for external contributors and shouldn't have been run during pull requests.

This only deploys Sanity schema changes on push to `main`. Adds a CI check to pull requests to validate the schema changes beforehand.