### PR TITLE
Update to pnpm v11 and set `allowBuilds`

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "vitest": "4.1.5",
     "wrangler": "^4.82.2"
   },
-  "packageManager": "pnpm@10.23.0",
+  "packageManager": "pnpm@11.0.0",
   "homepage": "https://namesake.fyi",
   "bugs": {
     "url": "https://github.com/namesakefyi/namesake/issues"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  esbuild: true
+  "@parcel/watcher": false
+  sharp: false
+  simple-git-hooks: false
+  workerd: false


### PR DESCRIPTION
Resolves #507.

Upgrade to pnpm v11 and set `pnpm allow-builds esbuild`. Creates a `pnpm-workspace` file with the appropriate settings.