### PR TITLE
fix(storybook): add missing font-face declarations

### DIFF
--- a/.storybook/fonts.css
+++ b/.storybook/fonts.css
@@ -1,0 +1,39 @@
+/* Font faces for Storybook only.
+ * Astro handles font loading for the main site via the Font API.
+ * These @font-face rules ensure Storybook renders with the correct fonts. */
+
+@font-face {
+  font-family: "Atkinson Hyperlegible Soft";
+  src: url("../src/fonts/AtkinsonHyperlegibleSoft-Regular.woff2") format("woff2");
+  font-weight: normal;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Atkinson Hyperlegible Soft";
+  src: url("../src/fonts/AtkinsonHyperlegibleSoft-Bold.woff2") format("woff2");
+  font-weight: bold;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Atkinson Hyperlegible Soft";
+  src: url("../src/fonts/AtkinsonHyperlegibleSoft-RegularItalic.woff2") format("woff2");
+  font-weight: normal;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Atkinson Hyperlegible Soft";
+  src: url("../src/fonts/AtkinsonHyperlegibleSoft-BoldItalic.woff2") format("woff2");
+  font-weight: bold;
+  font-style: italic;
+  font-display: swap;
+}
+
+:root {
+  --font-sans: "Atkinson Hyperlegible Soft", Helvetica, Arial, sans-serif;
+}

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -5,6 +5,8 @@ import React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { themes } from "storybook/theming";
 
+import "./fonts.css";
+
 import "../src/styles/base.css";
 import "../src/styles/reset.css";
 import "../src/styles/theme.css";


### PR DESCRIPTION
## What
Storybook was missing fonts after the Astro Font API migration in #480.

## Why
The Astro Font API generates `@font-face` rules and the `--font-sans` CSS variable at build time for the main site. Storybook doesn't have access to Astro's Font component, so it falls back to the browser default font.

## How
- Added `.storybook/fonts.css` with `@font-face` declarations for all 4 Atkinson Hyperlegible Soft font weights/styles
- Set `--font-sans` CSS variable to use the custom font with fallbacks
- Imported the new stylesheet in `.storybook/preview.tsx` before the existing style imports

This only affects Storybook — the main site continues using the Astro Font API.

Closes #500