### PR TITLE
Modify CI permissions to prevent contributor test runs from stalling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -64,7 +65,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run tests
         run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
   actions: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.storybook/storybook.css
+++ b/.storybook/storybook.css
@@ -3,7 +3,8 @@
   font-weight: 400;
   font-style: normal;
   font-display: swap;
-  src: url("../src/fonts/AtkinsonHyperlegibleSoft-Regular.woff2") format("woff2");
+  src: url("../src/fonts/AtkinsonHyperlegibleSoft-Regular.woff2")
+    format("woff2");
 }
 
 @font-face {
@@ -11,7 +12,8 @@
   font-weight: 400;
   font-style: italic;
   font-display: swap;
-  src: url("../src/fonts/AtkinsonHyperlegibleSoft-RegularItalic.woff2") format("woff2");
+  src: url("../src/fonts/AtkinsonHyperlegibleSoft-RegularItalic.woff2")
+    format("woff2");
 }
 
 @font-face {
@@ -27,7 +29,8 @@
   font-weight: 700;
   font-style: italic;
   font-display: swap;
-  src: url("../src/fonts/AtkinsonHyperlegibleSoft-BoldItalic.woff2") format("woff2");
+  src: url("../src/fonts/AtkinsonHyperlegibleSoft-BoldItalic.woff2")
+    format("woff2");
 }
 
 :root {


### PR DESCRIPTION
The `test` and `format` runs were stalling for some contributors. Adding `actions: write` permissions should fix this for future contributors.

Separately, fix a .css formatting issue from #501 which wasn't caught due to the stalled test run.