### PR TITLE
Prevent Vite from attempting to load CSS during PDF downloads

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -88,5 +88,19 @@ export default defineConfig({
     // build: {
     //   cssMinify: "lightningcss",
     // },
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (
+              id.includes("/src/constants/") &&
+              !id.includes("/src/constants/forms")
+            ) {
+              return "shared-constants";
+            }
+          },
+        },
+      },
+    },
   },
 });

--- a/src/components/forms/FormContainer/FormContainer.css
+++ b/src/components/forms/FormContainer/FormContainer.css
@@ -1,0 +1,18 @@
+.form-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-m);
+  width: 100%;
+  min-height: 100dvh;
+  padding-block-end: var(--space-m);
+}
+
+.form-container-content {
+  width: 100%;
+  padding-block-end: var(--space-xl);
+}
+
+.form-container-loading {
+  align-items: center;
+  justify-content: center;
+}

--- a/src/components/forms/FormContainer/FormContainer.tsx
+++ b/src/components/forms/FormContainer/FormContainer.tsx
@@ -16,6 +16,7 @@ import { FormNavigation } from "../FormNavigation";
 import { FormReviewStep } from "../FormReviewStep";
 import { FormTitleStep } from "../FormTitleStep/FormTitleStep";
 import { FormStepContext } from "./FormStepContext";
+import "./FormContainer.css";
 
 export interface FormContainerProps {
   /** Form slug to look up config. Must be registered in getFormConfig. */

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -216,22 +216,3 @@ textarea:focus-visible {
   filter: grayscale(100%);
   transform: translate3d(0, 0, 0);
 }
-
-.form-container {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-m);
-  width: 100%;
-  min-height: 100dvh;
-  padding-block-end: var(--space-m);
-}
-
-.form-container-content {
-  width: 100%;
-  padding-block-end: var(--space-xl);
-}
-
-.form-container-loading {
-  align-items: center;
-  justify-content: center;
-}


### PR DESCRIPTION
Followup to #523. Puts FormContainer.css styles back where they were, reverting #539 (which did not fix the issue). Adds a manual chunk for `shared-constants`.

Vite's CSS preload fails because of a Rollup chunk dependency created by shared constants.

The shared module chain `constants/countries` and `constants/jurisdictions` are runtime-imported by both:

1. `BirthplaceStep.tsx` (part of the FormContainer island, statically imported via socialSecurityConfig → constants/forms → FormContainer)
2. `formatBirthplaceCountryOrState.ts` (statically imported by the SS-5 PDF module)

Rollup sees these as shared modules. Because the FormContainer island is the dominant static importer, Rollup inlines countries/jurisdictions into the FormContainer chunk rather than creating a separate shared chunk. This creates a chunk-level dependency: SS-5 → FormContainer chunk.

Force the shared constants into their own chunk so SS-5's dependency doesn't pull in the FormContainer chunk (and its CSS).