### PR TITLE
fix: Preserve spaces between address parts in MapEmbed component

### DIFF
--- a/web/src/components/MapEmbed.astro
+++ b/web/src/components/MapEmbed.astro
@@ -12,12 +12,6 @@ interface Props {
   address: Address;
 }
 
-/**
- * Splits an address into its two display lines, joining each part with a
- * single space. Without this, the whitespace between the expressions in the
- * markup is collapsed and the parts run together, e.g. "Simpson Hall6
- * Harrington Road".
- */
 function formatAddress(address: Address) {
   return {
     line1: [address.address1, address.address2].filter(Boolean).join(" "),

--- a/web/src/components/MapEmbed.astro
+++ b/web/src/components/MapEmbed.astro
@@ -1,16 +1,32 @@
 ---
+interface Address {
+  address1: string;
+  address2?: string;
+  city: string;
+  state: string;
+  zip: string;
+}
+
 interface Props {
   name: string;
-  address: {
-    address1: string;
-    address2?: string;
-    city: string;
-    state: string;
-    zip: string;
+  address: Address;
+}
+
+/**
+ * Splits an address into its two display lines, joining each part with a
+ * single space. Without this, the whitespace between the expressions in the
+ * markup is collapsed and the parts run together, e.g. "Simpson Hall6
+ * Harrington Road".
+ */
+function formatAddress(address: Address) {
+  return {
+    line1: [address.address1, address.address2].filter(Boolean).join(" "),
+    line2: `${address.city}, ${address.state} ${address.zip}`,
   };
 }
 
 const { name, address } = Astro.props;
+const { line1, line2 } = formatAddress(address);
 
 const url = new URL("https://maps.google.com/maps");
 url.searchParams.set("q", name);
@@ -29,8 +45,9 @@ url.searchParams.set("output", "embed");
   </div>
   <figcaption class="map-address">
     <strong>{name}</strong><br />
-    {address.address1}{address.address2 && <>{" "}{address.address2}</>}<br />
-    {address.city}, {address.state}{" "}{address.zip}
+    {line1}
+    <br />
+    {line2}
   </figcaption>
 </figure>
 

--- a/web/src/components/MapEmbed.astro
+++ b/web/src/components/MapEmbed.astro
@@ -29,10 +29,8 @@ url.searchParams.set("output", "embed");
   </div>
   <figcaption class="map-address">
     <strong>{name}</strong><br />
-    {address.address1}
-    {address.address2}<br />
-    {address.city}, {address.state}
-    {address.zip}
+    {address.address1}{address.address2 && <>{" "}{address.address2}</>}<br />
+    {address.city}, {address.state}{" "}{address.zip}
   </figcaption>
 </figure>
 


### PR DESCRIPTION
Fixes #756

### Problem

`MapEmbed.astro` put each address part on its own source line:

```astro
{address.address1}
{address.address2}<br />
{address.city}, {address.state}
{address.zip}
```

JSX/Astro drops the whitespace that only comes from a newline between two expressions, so the rendered caption ran the parts together:

```
Simpson Hall6 Harrington Road
Cranston, Rhode Island02920
```

### Fix

Insert explicit `{" "}` separators. `address2` is optional, so its separator is rendered together with it — an address without a second line does not gain a trailing space before the `<br />`.

```astro
{address.address1}{address.address2 && <>{" "}{address.address2}</>}<br />
{address.city}, {address.state}{" "}{address.zip}
```

### Validation

Built the site (`pnpm --filter @namesake/web build:only`) and checked the two pages that use the component in `dist/`:

- `guides/ri/birth-certificate` (with `address2`) → `Simpson Hall 6 Harrington Road<br>Cranston, Rhode Island 02920`
- `guides/ri/court-order` (without `address2`) → `4 Howard Ave<br>Cranston, RI 02920`

Both now read correctly, and the no-`address2` case has no stray space.

- `pnpm exec astro check` → 0 errors, 0 warnings, 0 hints (558 files)
- `pnpm exec biome check web/src/components/MapEmbed.astro` → clean
