### PR TITLE
Disable `cssCodeSplit` to prevent form downloads from failing on first try

### DIFF
--- a/web/astro.config.ts
+++ b/web/astro.config.ts
@@ -92,6 +92,10 @@ export default defineConfig({
     },
     build: {
       cssMinify: "lightningcss",
+      // Prevent Vite from bundling FormContainer.css with otehr JS
+      // used when downloading forms. Was causing 404 /
+      // download failure on first attempt.
+      cssCodeSplit: false,
     },
   },
 });

--- a/web/astro.config.ts
+++ b/web/astro.config.ts
@@ -92,9 +92,9 @@ export default defineConfig({
     },
     build: {
       cssMinify: "lightningcss",
-      // Prevent Vite from bundling FormContainer.css with otehr JS
-      // used when downloading forms. Was causing 404 /
-      // download failure on first attempt.
+      // Prevent Vite attempting to fetch FormContainer.css
+      // during form downloads. Downloads were previously
+      // failing on 1st try due to how Vite bundles code.
       cssCodeSplit: false,
     },
   },


### PR DESCRIPTION
Fixes the issue described here: https://github.com/namesakefyi/namesake/pull/753#issuecomment-5646259884

Disable `cssCodeSplit` in the build config in order to prevent `FormContainer.css` from 404ing on the first attempt to download. TBH, not sure about all the nuances of Vite bundling at play here, but this *should* fix the issue without needing to set up a bunch of manual bundle chunks.